### PR TITLE
worker: respect all redis options identically to vultiserver

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -26,15 +26,20 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	redisAddr := cfg.Redis.Host + ":" + cfg.Redis.Port
-	client := asynq.NewClient(asynq.RedisClientOpt{Addr: redisAddr})
+	redisOptions := asynq.RedisClientOpt{
+		Addr:     cfg.Redis.Host + ":" + cfg.Redis.Port,
+		Username: cfg.Redis.User,
+		Password: cfg.Redis.Password,
+		DB:       cfg.Redis.DB,
+	}
+	client := asynq.NewClient(redisOptions)
 	workerServce, err := service.NewWorker(*cfg, client, sdClient, blockStorage)
 	if err != nil {
 		panic(err)
 	}
 
 	srv := asynq.NewServer(
-		asynq.RedisClientOpt{Addr: redisAddr},
+		redisOptions,
 		asynq.Config{
 			Logger:      logrus.StandardLogger(),
 			Concurrency: 10,


### PR DESCRIPTION
The worker program only consumes the redis config partially - specifically, it does not respect the database selector.

This change unifies the redis connection set up across both vultiserver and the worker.

It's necessary to enable local development work for plugins, where we need to run multiple independent instances of vultiserver simultaneously - splitting the queues by redis db is an easier option than running multiple instances of redis to manage.