### PR TITLE
dkls: use public go-wrappers repo

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,14 @@ jobs:
     - name: Install Clang
       run: sudo apt-get install -y clang
 
+    - name: Install dkls libraries
+      run: |
+        wget https://github.com/vultisig/go-wrappers/archive/refs/heads/master.tar.gz
+        tar -xzf master.tar.gz
+        cd go-wrappers-master
+        sudo mkdir -p /usr/local/lib/dkls
+        sudo cp --recursive includes /usr/local/lib/dkls
+        
     - name: Build
       run: go build -v ./...
       env:
@@ -31,7 +39,9 @@ jobs:
         CC: clang
 
     - name: Test
-      run: go test -v ./...
+      run: |
+        export LD_LIBRARY_PATH=/usr/local/lib/dkls/includes/linux/:$LD_LIBRARY_PATH
+        go test -v ./...
       env:
         CGO_ENABLED: 1
         CC: clang

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2
 	github.com/vultisig/commondata v0.0.0-20250122093634-15d19de47495
+	github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	go-wrapper v0.0.0-00010101000000-000000000000
 	google.golang.org/protobuf v1.35.1
 )
 
@@ -81,5 +81,4 @@ replace (
 	github.com/agl/ed25519 => github.com/binance-chain/edwards25519 v0.0.0-20200305024217-f36fc4b53d43
 	github.com/cwespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
-	go-wrapper => ../dkls23-rs/wrapper/go-wrappers/
 )

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vultisig/commondata v0.0.0-20250122093634-15d19de47495 h1:auxbLO9j16DD1f/uFqGoATyZZxgA4pOxynsZBbo/m2s=
 github.com/vultisig/commondata v0.0.0-20250122093634-15d19de47495/go.mod h1:UMc5q0Myab+BvzAe67UQrXTXwKGYNxK7bky7DJM+dl8=
+github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f h1:124Xlloih1FOOXv/HTdgl4syIRBa/xfKFXAecrZSPQE=
+github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f/go.mod h1:UfGCxUQW08kiwxyNBiHwXe+ePPuBmHVVS+BS51aU/Jg=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4nQ/NEVIb3OPP9SUx7/u9ZfsUIcd5fIN/e4DVU=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/service/mpc_wrapper.go
+++ b/service/mpc_wrapper.go
@@ -3,8 +3,8 @@ package service
 import (
 	"fmt"
 
-	session "go-wrapper/go-dkls/sessions"
-	eddsaSession "go-wrapper/go-schnorr/sessions"
+	session "github.com/vultisig/go-wrappers/go-dkls/sessions"
+	eddsaSession "github.com/vultisig/go-wrappers/go-schnorr/sessions"
 )
 
 type Handle int32


### PR DESCRIPTION
This switches to the https://github.com/vultisig/go-wrappers repo to allow the plugins project to slowly rely on vultiserver for more of the signing, keyshare related flows vs. duplicating it all