### PR TITLE
git-lfs: remove

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.a filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,10 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        lfs: 'true'
-    - name: Fetch Git LFS files
-      run: git lfs pull
 
     - name: Set up Go
       uses: actions/setup-go@v4


### PR DESCRIPTION
Removes git-lfs, which prevents the CI from building - with the removal of walletcore, we no longer have any lfs files.