### PR TITLE
Make email optional for plugin resahre

### DIFF
--- a/internal/types/reshare.go
+++ b/internal/types/reshare.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/ory/dockertest/docker/types"
 )
 
 type ReshareType int
@@ -54,7 +55,7 @@ func (req *ReshareRequest) IsValid() error {
 	if req.EncryptionPassword == "" {
 		return fmt.Errorf("encryption_password is required")
 	}
-	if req.Email == "" {
+	if req.Email == "" && req.ReshareType != types.Plugin {
 		return fmt.Errorf("email is required")
 	}
 	if len(req.OldParties) == 0 {


### PR DESCRIPTION
We don't need email for plugin reshare request