### PR TITLE
Add new error for wrong password

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -1,0 +1,5 @@
+package common
+
+import "errors"
+
+var ErrWrongPassword = errors.New("wrong password")

--- a/common/util.go
+++ b/common/util.go
@@ -141,7 +141,7 @@ func DecryptVaultFromBackup(password string, vaultBackupRaw []byte) (*vaultType.
 		}
 		vaultRaw, err = DecryptVault(password, vaultBytes)
 		if err != nil {
-			return nil, err
+			return nil, ErrWrongPassword
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for incorrect password attempts during vault operations, now returning a clear "invalid password" message and HTTP 401 Unauthorized status.
  * Enhanced feedback for users when entering a wrong password for vault-related actions.

* **Chores**
  * Standardized internal error handling for password validation across vault operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->