### PR TITLE
fix: add delay to ensure outbound messages are sent during key genera…

### DIFF
--- a/service/reshare_dkls.go
+++ b/service/reshare_dkls.go
@@ -223,6 +223,7 @@ func (t *DKLSTssService) processQcOutbound(handle Handle,
 	defer func() {
 		t.logger.Infof("finish processQcOutbound")
 	}()
+	var startTime *time.Time
 	for {
 		outbound, err := mpcKeygenWrapper.QcSessionOutputMessage(handle)
 		if err != nil {
@@ -230,6 +231,16 @@ func (t *DKLSTssService) processQcOutbound(handle Handle,
 		}
 		if len(outbound) == 0 {
 			if t.isKeygenFinished.Load() {
+				// even when the local party is finished , we better to wait for a little while to guarantee the outbound message is sent
+				if startTime == nil {
+					n := time.Now()
+					startTime = &n
+					continue
+				}
+
+				if time.Since(*startTime) < time.Second {
+					continue
+				}
 				// we are finished
 				return nil
 			}
@@ -360,6 +371,7 @@ func (t *DKLSTssService) processQcInbound(handle Handle,
 						t.logger.Error("fail to save local state", "error", err)
 						return "", "", err
 					}
+					time.Sleep(100 * time.Millisecond) // wait for a while to ensure the state is saved
 					return encodedPublicKey, chainCode, nil
 				}
 			}


### PR DESCRIPTION
…tion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves reliability of key generation and reshare flows by introducing a short grace window after completion to ensure all outbound messages are delivered, reducing the chance of missed messages.
  * Enhances stability during reshare by ensuring local state is fully persisted before proceeding, preventing rare timing-related inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->