### PR TITLE
feat: add ML-DSA support to batch import

### DIFF
--- a/internal/types/key_import.go
+++ b/internal/types/key_import.go
@@ -86,7 +86,7 @@ func (req *BatchImportRequest) IsValid() error {
 	if len(req.Protocols) == 0 {
 		return fmt.Errorf("protocols list is required")
 	}
-	known := map[string]bool{"ecdsa": true, "eddsa": true}
+	known := map[string]bool{"ecdsa": true, "eddsa": true, "mldsa": true}
 	seen := map[string]bool{}
 	for _, p := range req.Protocols {
 		if !known[p] {

--- a/service/import_batch.go
+++ b/service/import_batch.go
@@ -110,6 +110,7 @@ type importProtocolDef struct {
 	messageID string
 	setupKey  string
 	isEdDSA   bool
+	isMldsa   bool
 	isChain   bool
 	chain     string
 }
@@ -128,6 +129,16 @@ func importSetupKey(name string) string {
 func buildImportProtocolList(protocols []string, chains []string) []importProtocolDef {
 	var defs []importProtocolDef
 	for _, p := range protocols {
+		if p == "mldsa" {
+			defs = append(defs, importProtocolDef{
+				name:      "mldsa",
+				messageID: "p-mldsa",
+				setupKey:  "p-mldsa-setup",
+				isEdDSA:   true,
+				isMldsa:   true,
+			})
+			continue
+		}
 		isEdDSA := p == "eddsa"
 		defs = append(defs, importProtocolDef{
 			name:      p,
@@ -165,6 +176,15 @@ func (t *DKLSTssService) initImportProtocols(
 		if err != nil {
 			freeProtocols(protocols)
 			return nil, fmt.Errorf("setup for %s: %w", def.name, err)
+		}
+		if def.isMldsa {
+			p, kErr := NewMPCKeygenProtocol(def.name, def.messageID, setupMsg, localPartyID, true, true)
+			if kErr != nil {
+				freeProtocols(protocols)
+				return nil, fmt.Errorf("init keygen %s: %w", def.name, kErr)
+			}
+			protocols = append(protocols, p)
+			continue
 		}
 		p, err := NewMPCImportProtocol(def.name, def.messageID, setupMsg, localPartyID, def.isEdDSA)
 		if err != nil {
@@ -207,6 +227,8 @@ func (t *DKLSTssService) saveImportedVault(
 			vault.HexChainCode = pr.ChainCode
 		case "eddsa":
 			vault.PublicKeyEddsa = pr.PublicKey
+		case "mldsa":
+			vault.PublicKeyMldsa44 = pr.PublicKey
 		}
 	}
 

--- a/service/import_batch.go
+++ b/service/import_batch.go
@@ -134,7 +134,6 @@ func buildImportProtocolList(protocols []string, chains []string) []importProtoc
 				name:      "mldsa",
 				messageID: "p-mldsa",
 				setupKey:  "p-mldsa-setup",
-				isEdDSA:   true,
 				isMldsa:   true,
 			})
 			continue


### PR DESCRIPTION
## Summary
- Adds `mldsa` as a valid protocol in batch import validation
- Uses keygen protocol (not import) for ML-DSA during batch import, matching the batch keygen approach
- Saves ML-DSA public key to `PublicKeyMldsa44` on the vault

## Test plan
- [x] Tested locally with batch keygen including mldsa protocol
- [ ] Verify batch import with mldsa protocol on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added MLDSA protocol support for key imports and storage alongside existing ECDSA and EdDSA options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->