### PR TITLE
feat(vault): reject vault overwrite without ?force=true on collision

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -146,6 +146,12 @@ func (s *Server) CreateVault(c echo.Context) error {
 	if err := req.IsValid(); err != nil {
 		return fmt.Errorf("invalid request, err: %w", err)
 	}
+	// ?force=true allows overwriting an existing vault share for the same root
+	// ECDSA pubkey. Without it the worker rejects the overwrite to prevent
+	// silent share-mismatch for devices holding the prior share (spike item C).
+	if c.QueryParam("force") == "true" {
+		req.ForceOverwrite = true
+	}
 	buf, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("fail to marshal to json, err: %w", err)
@@ -362,6 +368,11 @@ func (s *Server) ImportVault(c echo.Context) error {
 	}
 	if err := req.IsValid(); err != nil {
 		return fmt.Errorf("invalid request, err: %w", err)
+	}
+	// ?force=true allows overwriting an existing vault share for the same root
+	// ECDSA pubkey. Without it the worker rejects the overwrite (spike item C).
+	if c.QueryParam("force") == "true" {
+		req.ForceOverwrite = true
 	}
 	buf, err := json.Marshal(req)
 	if err != nil {

--- a/internal/types/key_import.go
+++ b/internal/types/key_import.go
@@ -16,6 +16,11 @@ type KeyImportRequest struct {
 	EncryptionPassword string   `json:"encryption_password" validate:"required"` // password used to encrypt the vault file
 	Email              string   `json:"email" validate:"required"`               // this is the email of the user that the vault backup will be sent to
 	Chains             []string `json:"chains" validate:"required"`              // chains to import the key for
+	// ForceOverwrite allows overwriting an existing vault share for the same
+	// root ECDSA pubkey when the import produces different metadata.
+	// Without this flag the worker will reject the overwrite (ErrVaultCollision).
+	// Set via the ?force=true query param on POST /vault/import.
+	ForceOverwrite bool `json:"force_overwrite"`
 }
 
 func (req *KeyImportRequest) IsValid() error {

--- a/internal/types/vault.go
+++ b/internal/types/vault.go
@@ -25,6 +25,14 @@ type VaultCreateRequest struct {
 	EncryptionPassword string  `json:"encryption_password" validate:"required"` // password used to encrypt the vault file
 	Email              string  `json:"email" validate:"required"`               // this is the email of the user that the vault backup will be sent to
 	LibType            LibType `json:"lib_type"`                                // this is the type of the vault
+	// ForceOverwrite allows overwriting an existing vault share for the same
+	// root ECDSA pubkey when the new keygen produces different metadata.
+	// Without this flag the worker will reject the overwrite (ErrVaultCollision)
+	// to prevent silent share-mismatch for devices holding the prior share.
+	// Clients that have confirmed the user wants to replace the server backup
+	// (e.g. after showing a "Your existing vault share will be replaced" prompt)
+	// should set this to true. Set via the ?force=true query param on POST /vault/create.
+	ForceOverwrite bool `json:"force_overwrite"`
 }
 
 func isValidHexString(s string) bool {

--- a/service/dkls.go
+++ b/service/dkls.go
@@ -228,7 +228,7 @@ func (t *DKLSTssService) ProcessDKLSKeyImport(req types.KeyImportRequest) (strin
 	if t.backup == nil {
 		return publicKeyECDSA, publicKeyEdDSA, nil
 	}
-	if err := t.backup.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email); err != nil {
+	if err := t.backup.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email, req.ForceOverwrite); err != nil {
 		t.logger.WithFields(logrus.Fields{
 			"name":  req.Name,
 			"email": req.Email,
@@ -565,5 +565,8 @@ func (t *DKLSTssService) ProcessCreateMldsa(req types.CreateMldsaRequest) error 
 	})
 	vault.PublicKeyMldsa44 = mldsaPublicKey
 
-	return t.backup.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email)
+	// MLDSA extension always overwrites: it's adding a new key type to an
+	// already-registered vault. The metadata (ecdsa/eddsa/chaincode) is
+	// unchanged — only PublicKeyMldsa44 + the new keyshare are added.
+	return t.backup.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email, true)
 }

--- a/service/dkls_migration.go
+++ b/service/dkls_migration.go
@@ -163,7 +163,10 @@ func (t *DKLSTssService) ProceeMigration(vault *vaultType.Vault,
 		LibType:       keygenType.LibType_LIB_TYPE_DKLS,
 		ResharePrefix: "",
 	}
-	return t.backup.SaveVaultAndScheduleEmail(newVault, encryptionPassword, email)
+	// GG20-to-DKLS migration always overwrites: this path creates a new DKLS
+	// share for a vault that was previously under GG20. The intent is to
+	// replace the server share entirely.
+	return t.backup.SaveVaultAndScheduleEmail(newVault, encryptionPassword, email, true)
 }
 
 func (t *DKLSTssService) migrateWithRetry(publicKey string,

--- a/service/import_batch.go
+++ b/service/import_batch.go
@@ -247,5 +247,6 @@ func (t *DKLSTssService) saveImportedVault(
 		})
 	}
 
-	return t.backup.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email)
+	// Batch import is always a fresh ceremony that replaces the server share.
+	return t.backup.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email, true)
 }

--- a/service/keygen_batch.go
+++ b/service/keygen_batch.go
@@ -377,5 +377,6 @@ func (t *DKLSTssService) saveVault(
 		}
 	}
 
-	return t.backup.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email)
+	// Batch keygen is always a fresh ceremony that replaces the server share.
+	return t.backup.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email, true)
 }

--- a/service/reshare.go
+++ b/service/reshare.go
@@ -170,7 +170,8 @@ func (s *WorkerService) Reshare(vault *vaultType.Vault,
 		LibType:       keygenType.LibType_LIB_TYPE_GG20,
 		ResharePrefix: newResharePrefix,
 	}
-	return s.SaveVaultAndScheduleEmail(newVault, encryptionPassword, email)
+	// GG20 reshare always overwrites — same reasoning as the DKLS reshare path.
+	return s.SaveVaultAndScheduleEmail(newVault, encryptionPassword, email, true)
 }
 func (s *WorkerService) createVerificationCode(publicKeyECDSA string) (string, error) {
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -185,7 +186,30 @@ func (s *WorkerService) createVerificationCode(publicKeyECDSA string) (string, e
 }
 func (s *WorkerService) SaveVaultAndScheduleEmail(vault *vaultType.Vault,
 	encryptionPassword string,
-	email string) error {
+	email string,
+	forceOverwrite bool) error {
+	// Collision guard (spike item C): if a vault already exists for this ECDSA
+	// pubkey and its metadata differs, reject the overwrite unless the caller
+	// explicitly requests force. This prevents the server from silently
+	// replacing a live share while devices that hold the prior share still
+	// rely on it for signing.
+	//
+	// The check compares EdDSA pubkey, chain code, and local_party_id — the
+	// three fields that, if they drift, cause the share-mismatch pathology.
+	// An identical re-write (same metadata, same password) is always allowed.
+	//
+	// NOTE: we use the INCOMING encryption password to try to decrypt the
+	// existing file. If the password has changed (the user re-imported with a
+	// different password), decryption will fail and we conservatively allow
+	// the overwrite (we can't verify the existing metadata, so we can't block
+	// it). This mirrors the current permissive behaviour for password changes
+	// and avoids locking users out of a legitimate re-import.
+	if !forceOverwrite {
+		if err := s.checkVaultCollision(vault, encryptionPassword); err != nil {
+			return err
+		}
+	}
+
 	vaultData, err := proto.Marshal(vault)
 	if err != nil {
 		return fmt.Errorf("failed to Marshal vault: %w", err)
@@ -239,6 +263,66 @@ func (s *WorkerService) SaveVaultAndScheduleEmail(vault *vaultType.Vault,
 	s.logger.Info("Email task enqueued: ", taskInfo.ID)
 	return nil
 }
+// checkVaultCollision reads the existing vault file for the given ECDSA pubkey
+// (if any) and returns ErrVaultCollision when the existing vault has different
+// EdDSA pubkey, chain code, or local_party_id than the incoming vault.
+//
+// Returns nil when:
+//   - no existing vault (new registration — always allowed)
+//   - existing vault is identical to the incoming one (idempotent re-write)
+//   - existing vault file cannot be decrypted with the provided password (e.g.
+//     password changed — we conservatively allow the overwrite since we can't
+//     verify the existing metadata)
+func (s *WorkerService) checkVaultCollision(incoming *vaultType.Vault, password string) error {
+	filePathName := incoming.PublicKeyEcdsa + ".bak"
+	existing, err := s.blockStorage.GetFile(filePathName)
+	if err != nil {
+		// File does not exist — first registration, no collision possible.
+		return nil
+	}
+	return detectVaultCollision(incoming, password, existing, s.logger)
+}
+
+// detectVaultCollision is the pure core of checkVaultCollision, extracted so
+// it can be tested without a real BlockStorage.
+func detectVaultCollision(incoming *vaultType.Vault, password string, existingFileData []byte, logger *logrus.Logger) error {
+	existingVault, err := common.DecryptVaultFromBackup(password, existingFileData)
+	if err != nil {
+		// Can't decrypt — different password or corrupt file.
+		// Conservatively allow: we can't verify whether it collides.
+		if logger != nil {
+			logger.WithField("pubkey", incoming.PublicKeyEcdsa).
+				Warn("checkVaultCollision: failed to decrypt existing vault; allowing overwrite")
+		}
+		return nil
+	}
+
+	// Exact same metadata → idempotent re-write, always allow.
+	if existingVault.PublicKeyEddsa == incoming.PublicKeyEddsa &&
+		existingVault.HexChainCode == incoming.HexChainCode &&
+		existingVault.LocalPartyId == incoming.LocalPartyId {
+		return nil
+	}
+
+	if logger != nil {
+		logger.WithFields(logrus.Fields{
+			"pubkey":             incoming.PublicKeyEcdsa,
+			"existing_eddsa":     existingVault.PublicKeyEddsa,
+			"incoming_eddsa":     incoming.PublicKeyEddsa,
+			"existing_chaincode": existingVault.HexChainCode,
+			"incoming_chaincode": incoming.HexChainCode,
+			"existing_partyid":   existingVault.LocalPartyId,
+			"incoming_partyid":   incoming.LocalPartyId,
+		}).Warn("checkVaultCollision: vault metadata mismatch, rejecting overwrite (use ?force=true to override)")
+	}
+
+	return fmt.Errorf("%w (existing_eddsa=%s incoming_eddsa=%s)",
+		ErrVaultCollision,
+		existingVault.PublicKeyEddsa,
+		incoming.PublicKeyEddsa,
+	)
+}
+
 func getOldParties(newParties []string, oldSignerCommittee []string) []string {
 	oldParties := make([]string, 0)
 	for _, party := range oldSignerCommittee {

--- a/service/reshare.go
+++ b/service/reshare.go
@@ -286,6 +286,10 @@ func (s *WorkerService) checkVaultCollision(incoming *vaultType.Vault, password 
 // detectVaultCollision is the pure core of checkVaultCollision, extracted so
 // it can be tested without a real BlockStorage.
 func detectVaultCollision(incoming *vaultType.Vault, password string, existingFileData []byte, logger *logrus.Logger) error {
+	if len(existingFileData) == 0 {
+		// No existing file data — first registration, no collision possible.
+		return nil
+	}
 	existingVault, err := common.DecryptVaultFromBackup(password, existingFileData)
 	if err != nil {
 		// Can't decrypt — different password or corrupt file.

--- a/service/reshare_batch.go
+++ b/service/reshare_batch.go
@@ -239,5 +239,6 @@ func (t *DKLSTssService) saveResharedVault(
 		}
 	}
 
-	return t.backup.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email)
+	// Batch reshare is always a fresh ceremony that replaces the server share.
+	return t.backup.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email, true)
 }

--- a/service/reshare_dkls.go
+++ b/service/reshare_dkls.go
@@ -120,7 +120,9 @@ func (t *DKLSTssService) ProcessReshare(vault *vaultType.Vault,
 		LibType:       keygenType.LibType_LIB_TYPE_DKLS,
 		ResharePrefix: "",
 	}
-	return t.backup.SaveVaultAndScheduleEmail(newVault, encryptionPassword, email)
+	// Reshare always overwrites: the intent of a reshare is to replace the
+	// server share with a freshly-generated one from the ceremony.
+	return t.backup.SaveVaultAndScheduleEmail(newVault, encryptionPassword, email, true)
 }
 func (t *DKLSTssService) reshareWithRetry(vault *vaultType.Vault,
 	sessionID string,

--- a/service/tss.go
+++ b/service/tss.go
@@ -24,9 +24,26 @@ import (
 	vaultType "github.com/vultisig/commondata/go/vultisig/vault/v1"
 )
 
+// ErrVaultCollision is returned by SaveVaultAndScheduleEmail when a vault with
+// the same root ECDSA pubkey already exists on the server but its metadata
+// (EdDSA pubkey, chain code, or server party-id) differs from the incoming
+// vault. The caller must either use forceOverwrite=true or surface the
+// collision to the user so they can make an informed decision.
+//
+// This prevents silent share-mismatch: devices holding the prior share would
+// lose the ability to sign after the server backup is overwritten by a
+// re-keygen or re-import from another device (spike item C).
+var ErrVaultCollision = errors.New("vault_collision: a vault with this pubkey already exists with different metadata; use ?force=true to overwrite")
+
 type VaultOperation interface {
 	BackupVault(req types.VaultCreateRequest, partiesJoined []string, ecdsaPubkey, eddsaPubkey, hexChainCode string, localStateAccessor *relay.LocalStateAccessorImp) error
-	SaveVaultAndScheduleEmail(vault *vaultType.Vault, encryptionPassword, email string) error
+	// SaveVaultAndScheduleEmail writes the vault to block storage and enqueues
+	// the backup email. When forceOverwrite is false and a vault already exists
+	// for vault.PublicKeyEcdsa with different EdDSA pubkey, chain code, or
+	// local_party_id, returns ErrVaultCollision without overwriting the existing
+	// share. Pass forceOverwrite=true only when the user has explicitly
+	// consented to replacing the server backup (e.g. reimport via ?force=true).
+	SaveVaultAndScheduleEmail(vault *vaultType.Vault, encryptionPassword, email string, forceOverwrite bool) error
 }
 
 func (s *WorkerService) JoinKeyGeneration(req types.VaultCreateRequest) (string, string, error) {
@@ -205,7 +222,7 @@ func (s *WorkerService) BackupVault(req types.VaultCreateRequest,
 	default:
 		return fmt.Errorf("invalid lib type for vault: %d", req.LibType)
 	}
-	return s.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email)
+	return s.SaveVaultAndScheduleEmail(vault, req.EncryptionPassword, req.Email, req.ForceOverwrite)
 }
 
 func (s *WorkerService) createTSSService(serverURL, Session, HexEncryptionKey string, localStateAccessor tss.LocalStateAccessor, createPreParam bool, messageID string) (*tss.ServiceImpl, error) {

--- a/service/vault_collision_test.go
+++ b/service/vault_collision_test.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	vaultType "github.com/vultisig/commondata/go/vultisig/vault/v1"
+
+	"github.com/vultisig/vultiserver/common"
+)
+
+const testPassword = "hunter2"
+
+// buildEncryptedVaultFile builds an encrypted vault backup file (base64-encoded
+// proto) matching the format produced by SaveVaultAndScheduleEmail.
+func buildEncryptedVaultFile(t *testing.T, v *vaultType.Vault, password string) []byte {
+	t.Helper()
+	vaultData, err := proto.Marshal(v)
+	if err != nil {
+		t.Fatalf("proto.Marshal(vault): %v", err)
+	}
+	encrypted, err := common.EncryptVault(password, vaultData)
+	if err != nil {
+		t.Fatalf("common.EncryptVault: %v", err)
+	}
+	container := &vaultType.VaultContainer{
+		Version:     1,
+		Vault:       base64.StdEncoding.EncodeToString(encrypted),
+		IsEncrypted: true,
+	}
+	containerBytes, err := proto.Marshal(container)
+	if err != nil {
+		t.Fatalf("proto.Marshal(container): %v", err)
+	}
+	return []byte(base64.StdEncoding.EncodeToString(containerBytes))
+}
+
+func makeVault(ecdsa, eddsa, chainCode, partyID string) *vaultType.Vault {
+	return &vaultType.Vault{
+		Name:           "test-vault",
+		PublicKeyEcdsa: ecdsa,
+		PublicKeyEddsa: eddsa,
+		HexChainCode:   chainCode,
+		LocalPartyId:   partyID,
+		CreatedAt:      timestamppb.Now(),
+	}
+}
+
+// TestDetectVaultCollision_NoExistingFile verifies that passing nil / empty
+// file data returns nil (no collision for a new registration).
+func TestDetectVaultCollision_NoExistingFile(t *testing.T) {
+	// We model "file not found" by never calling detectVaultCollision —
+	// checkVaultCollision returns nil on GetFile error. Here we test the pure
+	// helper with a nil slice, which DecryptVaultFromBackup will fail to parse,
+	// triggering the "can't decrypt → allow" path. That's a slightly different
+	// path from "file not found" but both result in nil.
+	//
+	// The "file not found" case is covered by the nil-input test.
+	incoming := makeVault("ecdsa-01", "eddsa-01", "chaincode01", "Server-12345")
+	err := detectVaultCollision(incoming, testPassword, nil, nil)
+	if err != nil {
+		t.Fatalf("expected nil for no existing file, got: %v", err)
+	}
+}
+
+// TestDetectVaultCollision_IdenticalMetadata verifies that an idempotent
+// re-write (all metadata identical) is allowed.
+func TestDetectVaultCollision_IdenticalMetadata(t *testing.T) {
+	existing := makeVault("ecdsa-01", "eddsa-01", "chaincode01", "Server-12345")
+	incoming := makeVault("ecdsa-01", "eddsa-01", "chaincode01", "Server-12345")
+	fileData := buildEncryptedVaultFile(t, existing, testPassword)
+
+	err := detectVaultCollision(incoming, testPassword, fileData, nil)
+	if err != nil {
+		t.Fatalf("expected nil for identical metadata, got: %v", err)
+	}
+}
+
+// TestDetectVaultCollision_EddsaPubkeyDrifted verifies that a different EdDSA
+// pubkey triggers ErrVaultCollision.
+func TestDetectVaultCollision_EddsaPubkeyDrifted(t *testing.T) {
+	existing := makeVault("ecdsa-01", "eddsa-ORIGINAL", "chaincode01", "Server-12345")
+	incoming := makeVault("ecdsa-01", "eddsa-DRIFTED", "chaincode01", "Server-12345")
+	fileData := buildEncryptedVaultFile(t, existing, testPassword)
+
+	err := detectVaultCollision(incoming, testPassword, fileData, nil)
+	if !errors.Is(err, ErrVaultCollision) {
+		t.Fatalf("expected ErrVaultCollision for eddsa drift, got: %v", err)
+	}
+}
+
+// TestDetectVaultCollision_ChainCodeDrifted verifies that a different chain
+// code triggers ErrVaultCollision.
+func TestDetectVaultCollision_ChainCodeDrifted(t *testing.T) {
+	existing := makeVault("ecdsa-01", "eddsa-01", "chaincode-ORIGINAL", "Server-12345")
+	incoming := makeVault("ecdsa-01", "eddsa-01", "chaincode-DRIFTED", "Server-12345")
+	fileData := buildEncryptedVaultFile(t, existing, testPassword)
+
+	err := detectVaultCollision(incoming, testPassword, fileData, nil)
+	if !errors.Is(err, ErrVaultCollision) {
+		t.Fatalf("expected ErrVaultCollision for chain code drift, got: %v", err)
+	}
+}
+
+// TestDetectVaultCollision_PartyIdDrifted verifies that a different
+// local_party_id (server signer) triggers ErrVaultCollision.
+func TestDetectVaultCollision_PartyIdDrifted(t *testing.T) {
+	existing := makeVault("ecdsa-01", "eddsa-01", "chaincode01", "Server-11111")
+	incoming := makeVault("ecdsa-01", "eddsa-01", "chaincode01", "Server-99999")
+	fileData := buildEncryptedVaultFile(t, existing, testPassword)
+
+	err := detectVaultCollision(incoming, testPassword, fileData, nil)
+	if !errors.Is(err, ErrVaultCollision) {
+		t.Fatalf("expected ErrVaultCollision for party_id drift, got: %v", err)
+	}
+}
+
+// TestDetectVaultCollision_WrongPassword verifies that when the existing vault
+// can't be decrypted (wrong password), we conservatively allow the overwrite.
+func TestDetectVaultCollision_WrongPassword(t *testing.T) {
+	existing := makeVault("ecdsa-01", "eddsa-01", "chaincode01", "Server-12345")
+	incoming := makeVault("ecdsa-01", "eddsa-DRIFTED", "chaincode01", "Server-99999")
+	// Encrypt with a DIFFERENT password so decryption with testPassword fails.
+	fileData := buildEncryptedVaultFile(t, existing, "different-password")
+
+	err := detectVaultCollision(incoming, testPassword, fileData, nil)
+	if err != nil {
+		t.Fatalf("expected nil (conservatively allow) when existing can't be decrypted, got: %v", err)
+	}
+}


### PR DESCRIPTION
Item C from the DKLS share-mismatch spike - prevents silent overwrite of a live server share when a re-keygen or re-import produces different metadata.

## what

Without this guard, any device that re-registers the same root ECDSA pubkey via POST /vault/create or POST /vault/import silently replaces the server share. Devices holding the prior share then fail to sign with a confusing native DKLS error - the root cause of the share-mismatch pathology from the spike.

**Changes:**

`?force=true` query param on POST /vault/create and POST /vault/import bypasses the guard (explicit operator intent). Without it:

1. `SaveVaultAndScheduleEmail` calls `checkVaultCollision` before writing
2. `checkVaultCollision` reads the existing file from block storage, decrypts it with the incoming password, and calls `detectVaultCollision`
3. `detectVaultCollision` (pure function - no external deps) compares eddsa pubkey, chain code, and local_party_id
4. On mismatch: returns `ErrVaultCollision` (the worker logs it and the write is skipped)
5. File-not-found, identical metadata, or wrong-password-can't-decrypt all allow the write through

**On forceOverwrite=true in batch/reshare/migration paths:**

Reshare, migration, and MLDSA extension paths always pass `forceOverwrite=true` - they intentionally replace the server share as part of an explicit ceremony. Three batch paths (`import_batch`, `keygen_batch`, `reshare_batch`) also pass `true`.

This is intentional. These are multi-party MPC ceremonies that require ALL parties to participate - they can't be unilaterally triggered by a single device without the full ceremony completing. The MPC ceremony is itself the authorization proof. Specific rationale:
- `reshare` / `reshare_batch` / `reshare_dkls`: replacing keyshares is the entire purpose of reshare
- `keygen_batch`: bulk vault creation ceremony - produces a new vault, no existing share to protect
- `import_batch`: bulk migration ceremony, fresh keygen per shard - again ceremony-authorized
- `dkls_migration` (MLDSA extension): appends a quantum key; ECDSA/EdDSA/chain_code are unchanged so the guard would pass anyway

The collision guard is load-bearing only on the **user-facing** single-device routes (`CreateVault`, `ImportVault`) where a device can silently re-register after a share mismatch. That's exactly where the spike pathology lives.

**`detectVaultCollision` is extracted as a pure function** (no blockStorage dep) so it can be unit-tested without S3 or redis:

```go
func detectVaultCollision(incoming *vaultType.Vault, encryptionPassword string, existingFileData []byte, logger *logrus.Logger) error
```

## test delta

+6 tests in `service/vault_collision_test.go`:
- `TestDetectVaultCollision_NoExistingFile` - nil/empty data -> allow
- `TestDetectVaultCollision_IdenticalMetadata` - idempotent re-write -> allow
- `TestDetectVaultCollision_EddsaPubkeyDrifted` - eddsa mismatch -> ErrVaultCollision
- `TestDetectVaultCollision_ChainCodeDrifted` - chain code mismatch -> ErrVaultCollision
- `TestDetectVaultCollision_PartyIdDrifted` - local_party_id mismatch -> ErrVaultCollision
- `TestDetectVaultCollision_WrongPassword` - can't decrypt existing -> allow (conservative)

## receipts

```bash
# All 6 detectVaultCollision tests pass on CI (ubuntu, go 1.22, dkls linux libs):
go test ./service/... -run TestDetectVaultCollision -v
# === RUN   TestDetectVaultCollision_NoExistingFile
# --- PASS: TestDetectVaultCollision_NoExistingFile (0.00s)
# === RUN   TestDetectVaultCollision_IdenticalMetadata
# --- PASS: TestDetectVaultCollision_IdenticalMetadata (0.00s)
# === RUN   TestDetectVaultCollision_EddsaPubkeyDrifted
# --- PASS: TestDetectVaultCollision_EddsaPubkeyDrifted (0.00s)
# === RUN   TestDetectVaultCollision_ChainCodeDrifted
# --- PASS: TestDetectVaultCollision_ChainCodeDrifted (0.00s)
# === RUN   TestDetectVaultCollision_PartyIdDrifted
# --- PASS: TestDetectVaultCollision_PartyIdDrifted (0.00s)
# === RUN   TestDetectVaultCollision_WrongPassword
# --- PASS: TestDetectVaultCollision_WrongPassword (0.00s)
# PASS
# ok      github.com/vultisig/vultiserver/service 0.007s

# Build clean:
go build ./...
# (exit 0)

# Internal/types tests:
go test ./internal/...
# ok      github.com/vultisig/vultiserver/internal/types   0.276s
```

**Fix committed in `43e7391`:** `detectVaultCollision` now early-returns nil when `existingFileData` is nil/empty. `base64.StdEncoding.DecodeString("") + proto.Unmarshal([]byte{})` both succeed and return an empty `*vaultType.Vault`, which compared against a real incoming vault produced a false `ErrVaultCollision`. The guard now correctly treats no-existing-file as "first registration, allowed".

Paired FE: vultiagent-app#942 (PostHog telemetry + response pubkey verify)

🤖 Agent-generated
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
