### PR TITLE
fix(keyimport): classify Bittensor as EdDSA so import runs Schnorr not DKLS

### DIFF
--- a/service/dkls.go
+++ b/service/dkls.go
@@ -29,6 +29,7 @@ var TssKeyGenTimeout = errors.New("keygen timeout")
 var EddsaChains = []string{
 	"Solana",
 	"Polkadot",
+	"Bittensor",
 	"Sui",
 	"Cardano",
 	"Ton",

--- a/test/keygen_batch/batch_import_test.go
+++ b/test/keygen_batch/batch_import_test.go
@@ -14,7 +14,7 @@ type importProtocolDef struct {
 	chain     string
 }
 
-var eddsaChains = []string{"Solana", "Polkadot", "Sui", "Cardano", "Ton"}
+var eddsaChains = []string{"Solana", "Polkadot", "Bittensor", "Sui", "Cardano", "Ton"}
 
 func importSetupKey(name string) string {
 	switch name {
@@ -107,6 +107,7 @@ func TestBuildImportProtocolListEdDSAChainClassification(t *testing.T) {
 	}{
 		{"Solana", true},
 		{"Polkadot", true},
+		{"Bittensor", true},
 		{"Sui", true},
 		{"Cardano", true},
 		{"Ton", true},


### PR DESCRIPTION
## Root cause

Seed-phrase **key import for Bittensor hung the client forever**. `"Bittensor"` was missing from the server's `EddsaChains` whitelist (`service/dkls.go`), so the import dispatcher classified Bittensor as **ECDSA** and ran a **DKLS** ceremony on `p-Bittensor`. Clients, however, run a **Schnorr/EdDSA** ceremony for Bittensor — it shares Polkadot's ed25519 key (WalletCore `CoinType.polkadot`). The **curve mismatch** meant the server never emitted the Schnorr round-1 the client polls for, so the import **stalled permanently**.

Polkadot (already in `EddsaChains`) imports fine, which confirms the gap is specifically Bittensor's missing EdDSA classification.

## Fix

Add `"Bittensor"` to `EddsaChains` (placed next to `Polkadot`, since they share the curve/key). After this, Bittensor import runs as EdDSA/Schnorr, matching clients.

```diff
 var EddsaChains = []string{
 	"Solana",
 	"Polkadot",
+	"Bittensor",
 	"Sui",
 	"Cardano",
 	"Ton",
 }
```

## Why this is contained

`EddsaChains` is referenced **only on the import path** — `service/dkls.go` (`isEdDSAChain`, used by `keyImportWithRetry`) and `service/import_batch.go` (`isEdDSAChain` → `slices.Contains(EddsaChains, chain)`). It is **not** used by keygen, keysign, or reshare, so the blast radius is the import classification only.

**Keysign needs no change.** Import stores the raw chain string (`Chain: chain` in `service/dkls.go`), so keysign already resolves Bittensor correctly once import produces the right (EdDSA) key — no aliasing/rewrite required.

## Tests

- Updated the duplicated test whitelist `eddsaChains` in `test/keygen_batch/batch_import_test.go` to include `"Bittensor"`.
- Added a `{"Bittensor", true}` case to `TestBuildImportProtocolListEdDSAChainClassification` so a regression that drops Bittensor from `EddsaChains` is caught (the `{"Ethereum", false}` / `{"Bitcoin", false}` ECDSA-negative cases remain).

> Note: prod (`service/dkls.go`) and test (`test/keygen_batch/batch_import_test.go`) keep **two separate** EdDSA chain lists. The minimal fix updates both; unifying them into one shared list is a possible follow-up.

## Validation

- `gofmt -l service/dkls.go test/keygen_batch/batch_import_test.go` → clean (no output). Other `service/*.go` files flagged by `gofmt -l` are **pre-existing** and untouched by this PR.
- `go vet ./service/... ./test/...` → pass (exit 0).
- `go build ./...` → pass.
- `go test ./test/keygen_batch/... -run 'Import|EdDSA' -v` → **all pass**, including the new `Bittensor` classification case.
- Pure-Go packages (`common`, `internal/types`, `relay`, `test/keygen_batch`) pass under `go test ./...`. The `service` package test fails to load a hardcoded foreign Rust dylib (`/Users/johnny/.../libvscore.dylib`) — a **pre-existing local CGo/env issue** confirmed to fail identically on the unmodified base branch, unrelated to this change.

**Not verifiable locally:** end-to-end MPC import requires the relay + a real client, so this is validated by build + unit tests + the classification test, not a live import.

Closes vultisig/vultiserver#156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Bittensor as an EdDSA-compatible chain, enabling proper key generation and import operations for Bittensor users.

* **Tests**
  * Added validation to confirm Bittensor is correctly classified as an EdDSA chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->